### PR TITLE
jsonrpc: rm l2_getPendingBatch method

### DIFF
--- a/jsonrpc/l2.go
+++ b/jsonrpc/l2.go
@@ -15,14 +15,6 @@ func (c *Client) L2() *L2 {
 	return c.endpoints.l
 }
 
-// tx batch data is already encoded as params of AppendBatch in RollupInputChain.sol, just add a func selector beyond it
-// to invoke the AppendBatch is fine.
-func (l *L2) GetPendingTxBatches() ([]byte, error) {
-	var out hexutil.Bytes
-	err := l.c.Call("l2_getPendingTxBatches", &out)
-	return out, err
-}
-
 func (l *L2) GetRollupStateHash(batchIndex uint64) (web3.Hash, error) {
 	var out web3.Hash
 	err := l.c.Call("l2_getState", &out, batchIndex)

--- a/jsonrpc/l2_test.go
+++ b/jsonrpc/l2_test.go
@@ -77,17 +77,6 @@ func DecodeBatch(b []byte) error {
 	return nil
 }
 
-func TestL2_GetPendingTxBatches(t *testing.T) {
-	batch, err := getL2Client(t).GetPendingTxBatches()
-	if err != nil {
-		t.Skipf("skipping since client is not available")
-	}
-	if len(batch) > 0 { // try to decode
-		err := DecodeBatch(batch)
-		assert.NoError(t, err)
-	}
-}
-
 func TestL2_GetRollupStateHash(t *testing.T) {
 	info, err := getL2Client(t).GlobalInfo()
 	if err != nil {


### PR DESCRIPTION
# feature: rm l2_getPendingBatch method

## reason
The node no need to construct pending batch, the logic should be handled by users.

## replacement

Pending batch can be structed by users freely if they know:
- $1: L1 total batch related with total L2 block height
- $2: L1 pending queue index
- $3: get txs from block and figure out what is enqueued tx and what is origin L2 tx

Users  can get $1,$2 by l2_globalInfo rpc method, $3 the txs can be fetched by get_block and the tx can be figured out by nonce of tx.



