### PR TITLE
codec: check data existence

### DIFF
--- a/jsonrpc/codec/codec.go
+++ b/jsonrpc/codec/codec.go
@@ -39,9 +39,11 @@ type Subscription struct {
 
 // Error implements error interface
 func (e *ErrorObject) Error() string {
-	info, err := registry.ErrInstance().ParseError(hexutil.MustDecode(e.Data.(map[string]interface{})["data"].(string)))
-	if err == nil {
-		e.DecodedMessage = info
+	if data := e.Data.(map[string]interface{})["data"]; data != nil {
+		info, err := registry.ErrInstance().ParseError(hexutil.MustDecode(data.(string)))
+		if err == nil {
+			e.DecodedMessage = info
+		}
 	}
 	data, err := json.Marshal(e)
 	if err != nil {


### PR DESCRIPTION
# Bug

## What

at sometimes, the program may panic

```js
panic: interface conversion: interface {} is nil, not string

goroutine 53 [running]:
github.com/laizy/web3/jsonrpc/codec.(*ErrorObject).Error(0xc000d5a6c0)
        /Users/ubuntu/go/pkg/mod/github.com/laizy/web3@v0.1.14-0.20230221094440-1b8419578f57/jsonrpc/codec/codec.go:42 +0x165

``` 

## How 
the Data may not exist 

## Fix
check existence

